### PR TITLE
Add TypeScript declaration files for Webpack plugin

### DIFF
--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -1,0 +1,9 @@
+declare class Style9Plugin {
+  constructor(config?: { test: string | RegExp });
+
+  apply(compiler: typeof import("webpack")["Compiler"]): void;
+
+  static loader: typeof import("./loader");
+}
+
+export default Style9Plugin;

--- a/webpack/loader.d.ts
+++ b/webpack/loader.d.ts
@@ -1,0 +1,6 @@
+declare function style9Loader(
+  input: string,
+  inputSourceMap?: object | null
+): Promise<void>;
+
+export default style9Loader;

--- a/webpack/loader.d.ts
+++ b/webpack/loader.d.ts
@@ -1,6 +1,6 @@
 declare function style9Loader(
   input: string,
-  inputSourceMap?: object | null
+  inputSourceMap?: object | boolean
 ): Promise<void>;
 
 export default style9Loader;


### PR DESCRIPTION
This adds TS declarations for the Webpack plugin so that it can be used in `webpack.config.ts` files.