### PR TITLE
Include "filename" in the TransformOptions object passed to the Babel transformAsync call

### DIFF
--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -2,7 +2,7 @@ const babel = require('@babel/core');
 const babelPlugin = require('../babel.js');
 const loaderUtils = require('loader-utils');
 const virtualModules = require('./virtualModules.js');
-const path = require('path')
+const path = require('path');
 
 async function style9Loader(input, inputSourceMap) {
   const {

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -2,6 +2,7 @@ const babel = require('@babel/core');
 const babelPlugin = require('../babel.js');
 const loaderUtils = require('loader-utils');
 const virtualModules = require('./virtualModules.js');
+const path = require('path')
 
 async function style9Loader(input, inputSourceMap) {
   const {
@@ -16,6 +17,7 @@ async function style9Loader(input, inputSourceMap) {
     plugins: [[babelPlugin, options]],
     inputSourceMap: inputSourceMap || true,
     sourceFileName: this.resourcePath,
+    filename: path.basename(this.resourcePath),
     sourceMaps: true
   });
 


### PR DESCRIPTION
I've encountered a bug while using style9 wherein, if I am using `babel-loader` alongside the Style9 webpack loader and I have `@babel/preset-typescript` in the preset list in `babel.config.json` in the project root, Webback encounters an error during building. This PR fixes the issue.

## Steps to reproduce:
1. Clone this minimal reproduction repo I've created: https://github.com/nonAlgebraic/style9-babel-bug
2. Run `yarn install`
3. Run `yarn build`

## Expected result:
The Style9 loader and `babel-loader` work in harmony; the TypeScript files are transformed to JavaScript thanks to `@babel/preset-typescript` and the Style9 import and calls are compiled away.

## Actual result
Webpack throws an error during build which indicates that a `filename` property was not provided to some unnamed preset

```
Preset /* your preset */ requires a filename to be set when babel is called directly,
babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
See https://babeljs.io/docs/en/options#filename for more information.
```

If the Babel options are moved out of `babel.config.json` and instead are inlined within the `babel-loader` options in `webpack.config.js`, the error goes away.

**NOTE:** I can't say I fully understand the root cause of this bug; I only tried to resolve it. Hopefully this solution makes sense.