### PR TITLE
Fix webpack css loader postfix

### DIFF
--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -40,7 +40,7 @@ async function style9Loader(input, inputSourceMap) {
 
     virtualModules.writeModule(cssPath, metadata.style9);
 
-    const postfix = `import '${inlineLoader + cssPath}';`;
+    const postfix = `\nimport '${inlineLoader + cssPath}';`;
     this.callback(null, code + postfix, map);
   }
 }


### PR DESCRIPTION
Comment on last line of a source file meant webpack css loader import was also commented out. Added newline before postfix to fix.

Just been one of those mornings.