### PR TITLE
Exclude atrule type when parse css selector

### DIFF
--- a/__tests__/css-sorter.js
+++ b/__tests__/css-sorter.js
@@ -97,7 +97,12 @@ const CASES = [
       '.a{padding-top:2px}' +
       '.d{border-top:1px}' +
       '.c{border-top-width:2px}'
-  }
+  },
+  {
+    name: 'ignore atrule',
+    input: '@-ms-viewport {width:device-width}' + '.a{opacity:1}',
+    expected: '@-ms-viewport {width:device-width}' + '.a{opacity:1}'
+  },
 ];
 
 const IGNORE = [

--- a/src/process-css.js
+++ b/src/process-css.js
@@ -20,6 +20,8 @@ const PSEUDO_ORDER = [
   ':disabled'
 ];
 
+const EXCLUDE_RULE_TYPE = ['atrule'];
+
 function getPriority(prop) {
   return PROPERTY_PRIORITY[prop] || DEFAULT_PRIORITY;
 }
@@ -91,6 +93,9 @@ function extractDecls(decls) {
   const nodes = [];
 
   decls.forEach(rule => {
+    if (EXCLUDE_RULE_TYPE.includes(rule.parent.type)) {
+      return;
+    }
     const selectors = parseSelector(rule.parent);
     const isStyle9Selector = isValidSelector(selectors);
     if (!isStyle9Selector) return;


### PR DESCRIPTION
#41 

`@-ms-viewport { width: device-width; }`

Style9 recognizes '@-ms-view-port' as a selector rule, and tries to parse the selector.
But @-ms-viewport is more like a media query, with no selector property in the object from PostCSS.
Use postcss-selector-parser to parse an object without selector property will throw an exception.