### PR TITLE
Fix style9 params type to allow falsy values

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,18 +5,16 @@ interface StylePropertiesObject {
   [key: string]: StyleProperties;
 }
 
-declare function style9(...names: Style[]): string;
+type Falsy = false | null | undefined;
+
+declare function style9(...names: Array<Style | Falsy>): string;
 declare namespace style9 {
   function create<T>(
     styles: { [key in keyof T]: Style }
   ): { [key in keyof T]: Style } &
     ((
       ...names: Array<
-        | keyof T
-        | boolean
-        | undefined
-        | null
-        | { [key in keyof T]?: boolean | undefined | null }
+        keyof T | Falsy | { [key in keyof T]?: boolean | undefined | null }
       >
     ) => string);
   function keyframes(rules: StylePropertiesObject): string;

--- a/types/test/basic.ts
+++ b/types/test/basic.ts
@@ -3,7 +3,8 @@ import style9 from '../..';
 
 const styles = style9.create({
   blue: { color: 'blue' },
-  red: { color: 'red' }
+  red: { color: 'red' },
+  green: { color: 'green' }
 });
 
 // $ExpectType string
@@ -19,6 +20,13 @@ styles({
   blue: true
 });
 // $ExpectType string
+styles(false, undefined, null);
+// $ExpectType string
+styles({ blue: undefined, red: null, green: false });
+styles({ blue: undefined, red: null, green: true });
+// $ExpectType string
 style9(styles.blue);
 // $ExpectType string
-styles(true, false, undefined, null);
+style9(false, undefined, null);
+// $ExpectError
+style9(true);


### PR DESCRIPTION
Typing style9's params as `Style[]` does not account for it being able to also take falsy values - and ignore theme - which is helpful for style composition.

There is even already a test for this in [__tests__/resolver.js#L28-L35](https://github.com/johanholmerin/style9/blob/master/__tests__/resolver.js#L28-L35), so this really only aligns the type information with existing functionality.