### PR TITLE
add support for custom loaders in next.js plugin

### DIFF
--- a/next.js
+++ b/next.js
@@ -13,7 +13,7 @@ const cssLoader = (() => {
   }
 })();
 
-function getInlineLoader(options, MiniCssExtractPlugin) {
+function getInlineLoader(options, MiniCssExtractPlugin, ...loaders) {
   const outputLoaders = [{ loader: cssLoader }];
 
   if (!options.isServer) {
@@ -32,10 +32,14 @@ function getInlineLoader(options, MiniCssExtractPlugin) {
     });
   }
 
+  if (loaders.length > 0) {
+    outputLoaders.push(...loaders);
+  }
+
   return stringifyCssRequest(outputLoaders);
 }
 
-module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
+module.exports = (pluginOptions = {}, ...loaders) => (nextConfig = {}) => {
   return {
     ...nextConfig,
     webpack(config, options) {
@@ -64,7 +68,11 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
           {
             loader: Style9Plugin.loader,
             options: {
-              inlineLoader: getInlineLoader(options, MiniCssExtractPlugin),
+              inlineLoader: getInlineLoader(
+                options,
+                MiniCssExtractPlugin,
+                ...loaders
+              ),
               outputCSS,
               ...pluginOptions
             }


### PR DESCRIPTION
This PR enables the option to pass additional webpack loaders to the next.js plugin through a config object.

This is useful, for instance, in order to add a post-css pipeline to process the generated css file.

I will add tests once you indicate this is how you'd like to handle this, and that you have interest in the PR