### PR TITLE
Fix Next.js with webpack 5

### DIFF
--- a/next.js
+++ b/next.js
@@ -49,6 +49,12 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
         config = nextConfig.webpack(config, options);
       }
 
+      // For some reason, Next 11.0.1 has `config.optimization.splitChunks`
+      // set to `false` when webpack 5 is enabled.
+      config.optimization.splitChunks = config.optimization.splitChunks || {
+        cacheGroups: {}
+      };
+
       // Use own MiniCssExtractPlugin to ensure HMR works
       // v9 has issues when using own plugin in production
       // v10.2.1 has issues when using built-in plugin in development since it


### PR DESCRIPTION
I'm unsure why, but in `11.0.1` (or, more specifically, in [88ed526](https://github.com/vercel/next.js/commit/88ed5269b5e0c76667780f4823b669c392bc6713#diff-35e60cb9cfc6f14c2998799e7e5a28e5adfd6ededc273851531da3a1e506b0d4R616)) `config.optimization.splitChunks` was set to `false` when in dev mode, which breaks the Style9 Next.js plugin.

A word of caution: I don't understand the motivation behind the change in [88ed526](https://github.com/vercel/next.js/commit/88ed5269b5e0c76667780f4823b669c392bc6713#diff-35e60cb9cfc6f14c2998799e7e5a28e5adfd6ededc273851531da3a1e506b0d4R616), and therefore also unsure what this pull request might be breaking, if anything.