### PR TITLE
Fix issue with webpack5 cache

### DIFF
--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -32,6 +32,17 @@ async function style9Loader(input, inputSourceMap) {
     } else if (!outputCSS) {
       this.callback(null, code, map);
     } else {
+      // Webpack Virtual Module plugin doesn't support triggering a rebuild for webpack5,
+      // which can cause "module not found" error when webpack5 cache is enabled.
+      // Currently the only "non-hacky" workaround is to mark this module as non-cacheable.
+      //
+      // See also:
+      // - https://github.com/sysgears/webpack-virtual-modules/issues/86
+      // - https://github.com/sysgears/webpack-virtual-modules/issues/76
+      // - https://github.com/windicss/windicss-webpack-plugin/blob/bbb91323a2a0c0f880eecdf49b831be092ccf511/src/loaders/virtual-module.ts
+      // - https://github.com/sveltejs/svelte-loader/pull/151
+      this.cacheable(false);
+
       const cssPath = loaderUtils.interpolateName(
         this,
         '[path][name].[hash:base64:7].css',


### PR DESCRIPTION
Webpack Virtual Module plugin doesn't support triggering a rebuild for webpack5, which can cause the `module not found` error when webpack5 cache is enabled (E.g., Next.js enables webpack cache by default). Currently, the only workaround is to mark this module as non-cacheable, force updating the virtual module.

Related:

- https://github.com/sysgears/webpack-virtual-modules/issues/86
- https://github.com/sysgears/webpack-virtual-modules/issues/76
- https://github.com/windicss/windicss-webpack-plugin/blob/bbb91323a2a0c0f880eecdf49b831be092ccf511/src/loaders/virtual-module.ts
- https://github.com/sveltejs/svelte-loader/pull/151