### PR TITLE
Export `StyleWithAtRules` type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@ interface StylePropertiesObject {
   [key: string]: StyleProperties;
 }
 
-type StyleWithAtRules = Style<AtRulesProperties>;
+export type StyleWithAtRules = Style<AtRulesProperties>;
 
 // Should be kept in sync with ./4.3/index.d.ts
 declare function style9(...names: Array<StyleWithAtRules | Falsy>): string;


### PR DESCRIPTION
I am using in React component level based style composition:

```tsx
import style9 from 'style9';

const styles = style9.create({
  base: { /* */ }
});

export const SomeComponent = (props: {
  $style?: // How to type this?
}) => (
  <div classNames={style9(styles.base, props.$style)} />
);
```

```tsx
const styles = style9.create({
  extend: { /* */ }
});

<SomeComponent $style={styles.extend} />
```

With `StyleWithAtRules` being exported, I can type `SomeComponent` like this:

```tsx
import style9, { type StyleWithAtRules } from 'style9';

export const SomeComponent = (props: {
  $style?: StyleWithAtRules
}) => (
  <div classNames={style9(styles.base, props.$style)} />
);
```