### PR TITLE
Add `textDecoration` and `overflow` to `ExpandedShorthands`

### DIFF
--- a/types/Style.d.ts
+++ b/types/Style.d.ts
@@ -171,6 +171,8 @@ type ExpandedShorthands = Pick<
   | 'margin'
   | 'outline'
   | 'flex'
+  | 'textDecoration'
+  | 'overflow'
   // Incorrectly classified as longhand in csstype
   // | 'overscrollBehavior'
 >;


### PR DESCRIPTION
`text-decoration` support is added in https://github.com/robinweser/inline-style-expand-shorthand/pull/33
`overflow` support is added in https://github.com/robinweser/inline-style-expand-shorthand/pull/34

The PR is marked as a draft since those 2 PR hasn't been merged. I will mark the PR as ready for review once @robinweser releases a new version.