### PR TITLE
Use CommonJS in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function getValues(obj) {
   return values;
 }
 
-export default function style9(...styles) {
+function style9(...styles) {
   const merged = styles.reduce(merge, {});
   return getValues(merged).join(' ');
 }
@@ -37,3 +37,5 @@ style9.create = () => {
 style9.keyframes = () => {
   throw new Error('style9.keyframes calls should be compiled away');
 };
+
+module.exports = style9;


### PR DESCRIPTION
Context: I'm trying to use style9 in a project where front-end code gets rendered on a node server (i.e for server side rendering). Whenever I do this, I get the following error:

```
.../node_modules/style9/index.js:28
export default function style9(...styles) {
^^^^^^
SyntaxError: Unexpected token 'export'
```

Node doesn't recognize the import/export syntax in this file because there is no "type: module" declaration in the package.json.

This PR fixes the issue by using the CommonJS syntax in index.js, so that the module is parseable by node.