### PR TITLE
Improve style9 webpack performance

### DIFF
--- a/next.js
+++ b/next.js
@@ -108,6 +108,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
 
       config.module.rules.push({
         test: /\.(tsx|ts|js|mjs|jsx)$/,
+        exclude: /node_modules/,
         use: [
           {
             loader: Style9Plugin.loader,

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -2,6 +2,7 @@ const path = require('path');
 const babel = require('@babel/core');
 const loaderUtils = require('loader-utils');
 const babelPlugin = require('../babel.js');
+const NAME = require('../package.json').name; // style9
 const virtualModules = require('./virtualModules.js');
 
 async function style9Loader(input, inputSourceMap) {
@@ -16,6 +17,12 @@ async function style9Loader(input, inputSourceMap) {
   } = loaderUtils.getOptions(this) || {};
 
   this.async();
+
+  // bail out early if the input doesn't contain "style9"
+  if (!input.includes(NAME)) {
+    this.callback(null, input, inputSourceMap);
+    return;
+  }
 
   try {
     const { code, map, metadata } = await babel.transformAsync(input, {


### PR DESCRIPTION
The PR does two things:

- For Next.js plugin, exclude `node_modules` from style9 loader
  - A library that uses style9 should not be consumed directly, it should be transpiled before publishing to npm
  - The change doesn't affect existing webpack users (they will have to manually exclude `node_modules` if they want). The change only affects Next.js users.
- Make the style9 loader bail out early if the input doesn't include the `style9` string
  - The style9 babel plugin already bails out early if the import declaration doesn't contain `style9`, but for the webpack loader we can bail out even earlier to skip the entire `babel.parseAsync`.