### PR TITLE
Bump dependency for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inline-style-expand-shorthand": "^1.4.0",
     "json5": "2.2.1",
     "known-css-properties": "^0.19.0",
-    "loader-utils": "1.4.1",
+    "loader-utils": "1.4.2",
     "mini-css-extract-plugin": "^1.6.0",
     "murmurhash-js": "^1.0.0",
     "postcss": "^8.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4718,10 +4718,10 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.1.tgz#278ad7006660bccc4d2c0c1578e17c5c78d5c0e0"
-  integrity sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==
+loader-utils@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
- `loader-utils` from `1.4.1` to `1.4.2`
  - This fixes CVE-2022-37599 and CVE-2022-37603

The version is still pinned after the PR.