### PR TITLE
First attempt to support Next.js 13 appDir

### DIFF
--- a/next.js
+++ b/next.js
@@ -98,7 +98,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
       // https://github.com/vercel/next.js/pull/43916
       const hasAppDir =
         // on Next.js 12, findPagesDirResult is a string. on Next.js 13, findPagesDirResult is an object
-        !!nextConfig.experimental.appDir &&
+        !!(nextConfig.experimental && nextConfig.experimental.appDir) &&
         !!(findPagesDirResult && findPagesDirResult.appDir);
 
       const outputCSS = hasAppDir

--- a/next.js
+++ b/next.js
@@ -92,7 +92,11 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
   return {
     ...nextConfig,
     webpack(config, ctx) {
-      const findPagesDirResult = findPagesDir(ctx.dir);
+      const findPagesDirResult = findPagesDir(
+        ctx.dir,
+        nextConfig.experimental && nextConfig.experimental.appDir
+      );
+
       // https://github.com/vercel/next.js/blob/1fb4cad2a8329811b5ccde47217b4a6ae739124e/packages/next/build/index.ts#L336
       // https://github.com/vercel/next.js/blob/1fb4cad2a8329811b5ccde47217b4a6ae739124e/packages/next/build/webpack-config.ts#L626
       // https://github.com/vercel/next.js/pull/43916


### PR DESCRIPTION
cc @TxHawks @Dwlad90

Would you like to try the patch to see if it works?

Note the `appDir` might still not work, but the current `pages` is not affected (the behavior is retained, thus it is fully backward compatible).

See also:
- https://github.com/vanilla-extract-css/vanilla-extract/issues/929
- https://github.com/vercel/next.js/pull/43916
- https://github.com/vercel/next.js/issues/44266