### PR TITLE
chore: bump csstype to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/core": "^7.10.4",
     "@babel/types": "^7.8.3",
     "@rollup/pluginutils": "^3.0.4",
-    "csstype": "^3.0.6",
+    "csstype": "^3.1.1",
     "fast-json-stable-stringify": "^2.1.0",
     "inline-style-expand-shorthand": "^1.4.0",
     "json5": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,10 +2425,10 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.6:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
-  integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
+csstype@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
+  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
 cyclist@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The `csstype` in `dependencies` is `^3.0.6`, and `yarn.lock` shows that the exact version is `3.0.7`, which was released at 2021-02-24.

Since it's old, some types are not included, such as `-webkit-font-smoothing` and `-moz-osx-font-smoothing`. It's easy to make a workaround because users can declare `CustomProperties`, but it's also important to upgrade `csstype` to the newest version.

<details>
<summary>Proposal for handling this automatically</summary>

The repo should setup dependabot to sub-automatically upgrade its dependencies. To make it full-automatic, we can introduce automated testing such as `vitest` and `jest`.

If you're not familiar with them, I can make another pull request to introduce `vitest` or `jest`, but I'm afraid it's too difficult for me to make a well-considered test specification.
</details>