### PR TITLE
chore: use vendor longhand properties

### DIFF
--- a/types/Style.d.ts
+++ b/types/Style.d.ts
@@ -1,7 +1,7 @@
 import type {
   StandardShorthandProperties,
   StandardLonghandProperties,
-  VendorShorthandProperties,
+  VendorLonghandProperties,
   SimplePseudos
 } from 'csstype';
 
@@ -131,7 +131,7 @@ type StylePropertiesType = {
 
 interface StylePropertiesInternal
   extends ArrayStandardLonghandProperties,
-    VendorShorthandProperties<string | number>,
+    VendorLonghandProperties<string | number>,
     ExpandedShorthands,
     ExtendedStyleProperties,
     Omit<SvgProperties, keyof ArrayStandardLonghandProperties> {}


### PR DESCRIPTION
`VendorShorthandProperties` doesn't includes `MozOsxFontSmoothing` and `WebkitFontSmoothing`. Let's switch to `VendorLonghandProperties`. (I originally thought the type issue was due to the version of `csstype` and I open a pull request to upgrade it, I'm wrong.)

[Before the change](https://github.com/lixiang810/base65536-online/tree/style9), I have to [declare them myself](https://github.com/lixiang810/base65536-online/blob/style9/declaration.d.ts). [After the change](https://github.com/lixiang810/base65536-online/tree/style9-types), there's [no need for declaring](https://github.com/lixiang810/base65536-online/commit/22070ef74699dd8ff7f070a774ffe3e7d10aa223#diff-52cba71c9b30471a1918d0dbc55b1963ff54ee1691c490f89e4b2a9dc1f0c030). (After switching the branch, `pnpm i` and reload vscode (to restart typescript language server) to see effect.)

This will be some kind of breaking change since it will break some project using vendor shorthand properties, but I think it is [necessary](https://github.com/johanholmerin/style9/blob/master/docs/Background.md#no-shorthands). To avoid this situlation, we can use both `VendorShorthandProperties` and `VendorLonghandProperties`.