### PR TITLE
feat: support `require('style9')`

### DIFF
--- a/__tests__/code/import.js
+++ b/__tests__/code/import.js
@@ -6,24 +6,3 @@ it('ignores other imports', () => {
   const { code } = compile(input);
   expect(code).toBe(input);
 });
-
-it("support require('style9')", () => {
-  const input = `
-const style9 = require('style9');
-const styles = style9.create({
-  default: {
-    paddingLeft: 2
-  }
-});
-styles('default');
-  `;
-  const { styles, code } = compile(input);
-
-  expect(styles).toBe(`.hhTkCv{padding-left:2px}`);
-  expect(code).toMatchInlineSnapshot(`
-    "const style9 = require('style9');
-
-    const styles = {};
-    \\"hhTkCv \\";"
-  `);
-});

--- a/__tests__/code/import.js
+++ b/__tests__/code/import.js
@@ -6,3 +6,24 @@ it('ignores other imports', () => {
   const { code } = compile(input);
   expect(code).toBe(input);
 });
+
+it("support require('style9')", () => {
+  const input = `
+const style9 = require('style9');
+const styles = style9.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+styles('default');
+  `;
+  const { styles, code } = compile(input);
+
+  expect(styles).toBe(`.hhTkCv{padding-left:2px}`);
+  expect(code).toMatchInlineSnapshot(`
+    "const style9 = require('style9');
+
+    const styles = {};
+    \\"hhTkCv \\";"
+  `);
+});

--- a/__tests__/code/require.js
+++ b/__tests__/code/require.js
@@ -1,0 +1,159 @@
+/* eslint-env jest */
+const compile = require('../compile.js');
+
+describe("support require('style9')", () => {
+  it('#1', () => {
+    const input = `
+const style9 = require('style9');
+const styles = style9.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+styles('default');
+  `;
+    const { styles, code } = compile(input);
+
+    expect(styles).toBe(`.hhTkCv{padding-left:2px}`);
+    expect(code).toMatchInlineSnapshot(`
+          "const style9 = require('style9');
+
+          const styles = {};
+          \\"hhTkCv \\";"
+      `);
+  });
+
+  it('#2', () => {
+    const input = `
+let style9 = require('style9');
+const styles = style9.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+styles('default');
+  `;
+    const { styles, code } = compile(input);
+
+    expect(styles).toBe(`.hhTkCv{padding-left:2px}`);
+    expect(code).toMatchInlineSnapshot(`
+          "let style9 = require('style9');
+
+          const styles = {};
+          \\"hhTkCv \\";"
+      `);
+  });
+
+  it('#2', () => {
+    const input = `
+var style9 = require('style9');
+const styles = style9.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+styles('default');
+  `;
+    const { styles, code } = compile(input);
+
+    expect(styles).toBe(`.hhTkCv{padding-left:2px}`);
+    expect(code).toMatchInlineSnapshot(`
+          "var style9 = require('style9');
+
+          const styles = {};
+          \\"hhTkCv \\";"
+      `);
+  });
+
+  it('should ignore invalid require #1', () => {
+    const input = `
+const style9 = foo.require('style9');
+const style8 = require(style9);
+const styles = style9.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+styles('default');`;
+    const { code } = compile(input);
+    expect(code).toMatchInlineSnapshot(`
+      "const style9 = foo.require('style9');
+
+      const style8 = require(style9);
+
+      const styles = style9.create({
+        default: {
+          paddingLeft: 2
+        }
+      });
+      styles('default');"
+    `);
+  });
+
+  it('should ignore invalid require #2', () => {
+    const input = `
+const style9 = foo.require('style9');
+const style8 = foo(require('style9'));
+const style7 = require(style9);
+const style6 = require(style9)();
+const stylesA = style9.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+const stylesB = style8.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+const stylesC = style7.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+const stylesD = style6.create({
+  default: {
+    paddingLeft: 2
+  }
+});
+stylesA('default');
+stylesB('default');
+stylesC('default');
+stylesD('default');`;
+    const { code } = compile(input);
+    expect(code).toMatchInlineSnapshot(`
+      "const style9 = foo.require('style9');
+
+      const style8 = foo(require('style9'));
+
+      const style7 = require(style9);
+
+      const style6 = require(style9)();
+
+      const stylesA = style9.create({
+        default: {
+          paddingLeft: 2
+        }
+      });
+      const stylesB = style8.create({
+        default: {
+          paddingLeft: 2
+        }
+      });
+      const stylesC = style7.create({
+        default: {
+          paddingLeft: 2
+        }
+      });
+      const stylesD = style6.create({
+        default: {
+          paddingLeft: 2
+        }
+      });
+      stylesA('default');
+      stylesB('default');
+      stylesC('default');
+      stylesD('default');"
+    `);
+  });
+});

--- a/babel.js
+++ b/babel.js
@@ -1,6 +1,9 @@
 const NAME = require('./package.json').name;
 const processReferences = require('./src/process-references.js');
 
+/**
+ * @returns {import('@babel/core').PluginObj}
+ */
 module.exports = function style9BabelPlugin() {
   return {
     name: NAME,
@@ -16,6 +19,29 @@ module.exports = function style9BabelPlugin() {
           state.file.metadata.style9 = '';
         }
         state.file.metadata.style9 += css;
+      },
+      VariableDeclaration(path, state) {
+        for (const { node } of path.get('declarations')) {
+          // process require('style9')
+          if (
+            node.init?.type === 'CallExpression' &&
+            node.init?.callee.type === 'Identifier' &&
+            node.init?.callee.name === 'require' &&
+            node.init?.arguments.length === 1 &&
+            node.init?.arguments[0].type === 'StringLiteral' &&
+            node.init?.arguments[0].value === NAME &&
+            node.id.type === 'Identifier'
+          ) {
+            const importName = node.id.name;
+            const bindings = path.scope.bindings[importName].referencePaths;
+
+            const css = processReferences(bindings, state.opts).join('');
+            if (!state.file.metadata.style9) {
+              state.file.metadata.style9 = '';
+            }
+            state.file.metadata.style9 += css;
+          }
+        }
       }
     }
   };

--- a/babel.js
+++ b/babel.js
@@ -15,9 +15,7 @@ module.exports = function style9BabelPlugin() {
         const bindings = path.scope.bindings[importName].referencePaths;
 
         const css = processReferences(bindings, state.opts).join('');
-        if (!state.file.metadata.style9) {
-          state.file.metadata.style9 = '';
-        }
+        state.file.metadata.style9 = state.file.metadata.style9 || '';
         state.file.metadata.style9 += css;
       },
       VariableDeclaration(path, state) {
@@ -36,9 +34,7 @@ module.exports = function style9BabelPlugin() {
             const bindings = path.scope.bindings[importName].referencePaths;
 
             const css = processReferences(bindings, state.opts).join('');
-            if (!state.file.metadata.style9) {
-              state.file.metadata.style9 = '';
-            }
+            state.file.metadata.style9 = state.file.metadata.style9 || '';
             state.file.metadata.style9 += css;
           }
         }


### PR DESCRIPTION
Previously, `style9` only supports `import xxx from 'style9'`.
The PR adds support for `const xxx = require('style9')`.

The unit test case is added in `__tests__/code/import.js`.