### PR TITLE
perf: do not create bin expression with adjacented string

### DIFF
--- a/__tests__/code/fixtures/classes/complex-ternary/code.js
+++ b/__tests__/code/fixtures/classes/complex-ternary/code.js
@@ -1,51 +1,30 @@
 import style9 from 'style9';
 const styles = style9.create({
-  button: {
-    marginLeft: '0.5rem',
-    position: 'relative',
-    display: 'inline-flex',
-    flexShrink: 0,
+  not_used: {
     padding: '0',
-    height: '19px',
-    width: '35px',
-    borderWidth: '2px',
-    borderColor: 'transparent',
-    borderRadius: '9999px',
-    cursor: 'pointer',
-    transitionDuration: '50ms',
-    transitionTimingFunction: 'cubic-bezier(0.4, 0,0.2, 1)',
-    transitionProperty: 'background-color, border-color, color, fill, stroke',
+    cursor: 'pointer'
+  },
+  base: {
+    pointerEvents: 'none',
     ':focus': {
       outline: 'none'
     }
   },
-  disabled: {
-    backgroundColor: '#9ca3af'
-  },
   enabled: {
-    backgroundColor: '#059669'
+    color: 'green'
   },
-  toggle: {
-    pointerEvents: 'none',
-    display: 'inline-block',
-    height: '15px',
-    width: '15px',
-    borderRadius: '9999px',
-    backgroundColor: '#fff',
-    boxShadow:
-      '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-    animationDuration: '200ms',
-    lineHeight: '1.5rem',
-    fontSize: '1rem',
-    transitionTimingFunction: 'cubic-bezier(0.4, 0,0.2, 1)',
-    transitionDuration: '50ms'
+  disabled: {
+    color: 'red',
+    cursor: 'not-allowed'
   },
-  toggle__enabled: {
-    transform: 'translateX(1rem)'
+  hover: {
+    ':hover': {
+      color: 'blue'
+    }
   },
-  toggle__disabled: {
-    transform: 'translateX(0)'
+  other: {
+    backgroundColor: 'red'
   }
 });
 
-styles('toggle', checked ? 'toggle__enabled' : 'toggle__disabled');
+styles('base', checked ? 'enabled' : 'disabled', 'hover', 'other');

--- a/__tests__/code/fixtures/classes/complex-ternary/code.js
+++ b/__tests__/code/fixtures/classes/complex-ternary/code.js
@@ -1,0 +1,51 @@
+import style9 from 'style9';
+const styles = style9.create({
+  button: {
+    marginLeft: '0.5rem',
+    position: 'relative',
+    display: 'inline-flex',
+    flexShrink: 0,
+    padding: '0',
+    height: '19px',
+    width: '35px',
+    borderWidth: '2px',
+    borderColor: 'transparent',
+    borderRadius: '9999px',
+    cursor: 'pointer',
+    transitionDuration: '50ms',
+    transitionTimingFunction: 'cubic-bezier(0.4, 0,0.2, 1)',
+    transitionProperty: 'background-color, border-color, color, fill, stroke',
+    ':focus': {
+      outline: 'none'
+    }
+  },
+  disabled: {
+    backgroundColor: '#9ca3af'
+  },
+  enabled: {
+    backgroundColor: '#059669'
+  },
+  toggle: {
+    pointerEvents: 'none',
+    display: 'inline-block',
+    height: '15px',
+    width: '15px',
+    borderRadius: '9999px',
+    backgroundColor: '#fff',
+    boxShadow:
+      '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+    animationDuration: '200ms',
+    lineHeight: '1.5rem',
+    fontSize: '1rem',
+    transitionTimingFunction: 'cubic-bezier(0.4, 0,0.2, 1)',
+    transitionDuration: '50ms'
+  },
+  toggle__enabled: {
+    transform: 'translateX(1rem)'
+  },
+  toggle__disabled: {
+    transform: 'translateX(0)'
+  }
+});
+
+styles('toggle', checked ? 'toggle__enabled' : 'toggle__disabled');

--- a/__tests__/code/fixtures/classes/complex-ternary/output.js
+++ b/__tests__/code/fixtures/classes/complex-ternary/output.js
@@ -1,0 +1,18 @@
+import style9 from 'style9';
+const styles = {};
+'cpOcAb ' +
+  ('eNRbYf ' +
+    ('jJMEUn ' +
+      ('jWjrEQ ' +
+        ('eKtERL ' +
+          ('BRobm ' +
+            ('iovjFN ' +
+              ('dIIZah ' +
+                ('hAmKMv ' +
+                  ('dzEaaE ' +
+                    ('eDssNQ ' +
+                      ('jwTRBm ' +
+                        ('haLLXa ' +
+                          ('ljUXOK ' +
+                            ('fUqtKm ' +
+                              (checked ? 'gtDvVO ' : 'nIqxk ')))))))))))))));

--- a/__tests__/code/fixtures/classes/complex-ternary/output.js
+++ b/__tests__/code/fixtures/classes/complex-ternary/output.js
@@ -1,18 +1,4 @@
 import style9 from 'style9';
 const styles = {};
-'cpOcAb ' +
-  ('eNRbYf ' +
-    ('jJMEUn ' +
-      ('jWjrEQ ' +
-        ('eKtERL ' +
-          ('BRobm ' +
-            ('iovjFN ' +
-              ('dIIZah ' +
-                ('hAmKMv ' +
-                  ('dzEaaE ' +
-                    ('eDssNQ ' +
-                      ('jwTRBm ' +
-                        ('haLLXa ' +
-                          ('ljUXOK ' +
-                            ('fUqtKm ' +
-                              (checked ? 'gtDvVO ' : 'nIqxk ')))))))))))))));
+'cpOcAb eNRbYf jJMEUn jWjrEQ eKtERL BRobm iovjFN dIIZah hAmKMv dzEaaE eDssNQ jwTRBm haLLXa ljUXOK fUqtKm ' +
+  (checked ? 'gtDvVO ' : 'nIqxk ');

--- a/__tests__/code/fixtures/classes/complex-ternary/output.js
+++ b/__tests__/code/fixtures/classes/complex-ternary/output.js
@@ -1,4 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'cpOcAb eNRbYf jJMEUn jWjrEQ eKtERL BRobm iovjFN dIIZah hAmKMv dzEaaE eDssNQ jwTRBm haLLXa ljUXOK fUqtKm ' +
-  (checked ? 'gtDvVO ' : 'nIqxk ');
+'fYFPyg eDssNQ larHMv ' + ((checked ? 'ciOZAH ' : 'RCRUH ') + 'kKPCVy cGdbor ');

--- a/__tests__/code/fixtures/classes/string-literal/output.js
+++ b/__tests__/code/fixtures/classes/string-literal/output.js
@@ -1,3 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'RCRUH ' + 'gOeSjL ';
+('RCRUH gOeSjL ');

--- a/__tests__/code/fixtures/incremental-classnames/generated-classname/output.js
+++ b/__tests__/code/fixtures/incremental-classnames/generated-classname/output.js
@@ -1,3 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'a ' + ('b ' + 'c ');
+('a b c ');

--- a/__tests__/code/fixtures/nesting/at-rules/output.js
+++ b/__tests__/code/fixtures/nesting/at-rules/output.js
@@ -1,3 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'Bbwnu ' + 'cCpNNg ';
+('Bbwnu cCpNNg ');

--- a/__tests__/code/fixtures/values/expands-shorthand-in-nesting/output.js
+++ b/__tests__/code/fixtures/values/expands-shorthand-in-nesting/output.js
@@ -1,3 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'gDvCuo ' + ('cmluEy ' + ('fyByHi ' + 'isyUlq '));
+('gDvCuo cmluEy fyByHi isyUlq ');

--- a/__tests__/code/fixtures/values/expands-shorthand/output.js
+++ b/__tests__/code/fixtures/values/expands-shorthand/output.js
@@ -1,3 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'jWWtke ' + ('ftIldC ' + ('bnHxUw ' + 'iDuqPI '));
+('jWWtke ftIldC bnHxUw iDuqPI ');

--- a/__tests__/code/fixtures/values/keeps-longhand/output.js
+++ b/__tests__/code/fixtures/values/keeps-longhand/output.js
@@ -1,3 +1,3 @@
 import style9 from 'style9';
 const styles = {};
-'lcGuBB ' + ('ftIldC ' + ('bnHxUw ' + 'iigETV '));
+('lcGuBB ftIldC bnHxUw iigETV ');

--- a/src/helpers/generate-expression.js
+++ b/src/helpers/generate-expression.js
@@ -60,9 +60,10 @@ function generateExpression(args, classObject) {
       )
     );
 
-  const binaryExpression = conditionals.reduceRight((acc, expr) =>
-    t.binaryExpression('+', expr, acc)
-  );
+  const binaryExpression = conditionals.reduceRight((acc, expr) => {
+    if (t.isStringLiteral(expr) && expr.value === '') return acc;
+    return t.binaryExpression('+', expr, acc);
+  });
 
   return t.expressionStatement(binaryExpression);
 }

--- a/src/helpers/generate-expression.js
+++ b/src/helpers/generate-expression.js
@@ -61,26 +61,23 @@ function generateExpression(args, classObject) {
     );
 
   const simplifiedConditionals = [];
+  let stringBuffer = '';
 
-  if (originalConditionals.length > 0) {
-    let stringBuffer = '';
-
-    for (let i = 0; i < originalConditionals.length; i++) {
-      const conditional = originalConditionals[i];
-      if (t.isStringLiteral(conditional)) {
-        stringBuffer += conditional.value;
-      } else {
-        if (stringBuffer !== '') {
-          simplifiedConditionals.push(t.stringLiteral(stringBuffer));
-          stringBuffer = '';
-        }
-        simplifiedConditionals.push(conditional);
+  for (let i = 0; i < originalConditionals.length; i++) {
+    const conditional = originalConditionals[i];
+    if (t.isStringLiteral(conditional)) {
+      stringBuffer += conditional.value;
+    } else {
+      if (stringBuffer !== '') {
+        simplifiedConditionals.push(t.stringLiteral(stringBuffer));
+        stringBuffer = '';
       }
+      simplifiedConditionals.push(conditional);
     }
+  }
 
-    if (stringBuffer !== '') {
-      simplifiedConditionals.push(t.stringLiteral(stringBuffer));
-    }
+  if (stringBuffer !== '') {
+    simplifiedConditionals.push(t.stringLiteral(stringBuffer));
   }
 
   if (simplifiedConditionals.length === 0) {


### PR DESCRIPTION
I recently encountered an interesting case:

**styles**

```jsx
import style9 from 'style9';
const styles = style9.create({
  button: {
    marginLeft: '0.5rem',
    position: 'relative',
    display: 'inline-flex',
    flexShrink: 0,
    padding: '0',
    height: '19px',
    width: '35px',
    borderWidth: '2px',
    borderColor: 'transparent',
    borderRadius: '9999px',
    cursor: 'pointer',
    transitionDuration: '50ms',
    transitionTimingFunction: 'cubic-bezier(0.4, 0,0.2, 1)',
    transitionProperty: 'background-color, border-color, color, fill, stroke',
    ':focus': {
      outline: 'none'
    }
  },
  disabled: {
    backgroundColor: '#9ca3af'
  },
  enabled: {
    backgroundColor: '#059669'
  },
  toggle: {
    pointerEvents: 'none',
    display: 'inline-block',
    height: '15px',
    width: '15px',
    borderRadius: '9999px',
    backgroundColor: '#fff',
    boxShadow:
      '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
    animationDuration: '200ms',
    lineHeight: '1.5rem',
    fontSize: '1rem',
    transitionTimingFunction: 'cubic-bezier(0.4, 0,0.2, 1)',
    transitionDuration: '50ms'
  },
  toggle__enabled: {
    transform: 'translateX(1rem)'
  },
  toggle__disabled: {
    transform: 'translateX(0)'
  }
});
```

**input**

```js
styles('toggle', checked ? 'toggle__enabled' : 'toggle__disabled');
```

**output**

```js
'' + ('' + ('cpOcAb ' + ('' + ('' + ('' + ('' + ('' + ('eNRbYf ' + ('jJMEUn ' + ('' + ('' + ('' + ('' + ('' + ('' + ('' + ('' + ('jWjrEQ ' + ('eKtERL ' + ('BRobm ' + ('iovjFN ' + ('' + ('dIIZah ' + ('hAmKMv ' + ('' + ('' + ('dzEaaE ' + ('eDssNQ ' + ('jwTRBm ' + ('haLLXa ' + ('ljUXOK ' + ('fUqtKm ' + (checked ? 'gtDvVO ' : 'nIqxk ')))))))))))))))))))))))))))))))))
```

----

I am able to simplify the output by stripping the empty string out of the expression. After the PR, the output becomes:

```js
'cpOcAb eNRbYf jJMEUn jWjrEQ eKtERL BRobm iovjFN dIIZah hAmKMv dzEaaE eDssNQ jwTRBm haLLXa ljUXOK fUqtKm ' +
  (checked ? 'gtDvVO ' : 'nIqxk ');
```

I have created a test case against my change as well.