### PR TITLE
vite: run transform as early as possible

### DIFF
--- a/vite.js
+++ b/vite.js
@@ -71,16 +71,19 @@ module.exports = function style9Plugin(opts = {}) {
       if (id === VIRTUAL_CSS_NAME) return genCSS(cssModules);
       return null;
     },
-    transform(code, id) {
-      if (!filter(id)) {
-        return;
+    transform: {
+      order: 'pre',
+      handler(code, id) {
+        if (!filter(id)) {
+          return;
+        }
+        return transformStyle9(code, id, {
+          parserOptions,
+          restOptions,
+          cssModules,
+          server
+        });
       }
-      return transformStyle9(code, id, {
-        parserOptions,
-        restOptions,
-        cssModules,
-        server
-      });
     },
     renderChunk(_, chunk) {
       const ids = Object.keys(chunk.modules);


### PR DESCRIPTION
This is conceptually correct because style9 has to have been converted at bundle time. This fixes Qwik bundling, for example.